### PR TITLE
Fix payload packing

### DIFF
--- a/process_ipl.py
+++ b/process_ipl.py
@@ -115,10 +115,7 @@ def process_scrambled_ipl(ipl, size):
     out2 = int.from_bytes(ipl, byteorder='big', signed=False)
     out2 = out2 << 1
 
-    binary = ''.join([char * 4 for char in format(out2, 'b')])
-    binary = int(binary, 2)
-
-    payload = binary.to_bytes(size * 4, 'big')
+    payload = out2.to_bytes(size, 'big')
     
     return payload
     

--- a/process_ipl.py
+++ b/process_ipl.py
@@ -105,20 +105,6 @@ def generate_header_file(elements, executable, input_file, output_file, size):
 
     return output
 
-def process_scrambled_ipl(ipl, size):
-    """Does additional processing to scrambled IPL payload.
-
-    Payload used by PicoBoot has to be preprocessed. 
-    Whole payload has to be aligned to 1K blocks then every bit needs to be duplicated 4 times.
-    """
-    
-    out2 = int.from_bytes(ipl, byteorder='big', signed=False)
-    out2 = out2 << 1
-
-    payload = out2.to_bytes(size, 'big')
-    
-    return payload
-    
 def main():
     if len(sys.argv) != 3:
         print(f"Usage: {sys.argv[0]} <executable> <output>")
@@ -160,7 +146,7 @@ def main():
     scrambled_payload = scramble(payload)[0x700:]
     payload_size = len(scrambled_payload);
 
-    byte_groups = bytes_to_c_array(process_scrambled_ipl(scrambled_payload, payload_size))
+    byte_groups = bytes_to_c_array(scrambled_payload)
 
     output = generate_header_file(byte_groups, sys.argv[0], sys.argv[1], sys.argv[2], size)
 

--- a/src/picoboot.c
+++ b/src/picoboot.c
@@ -14,7 +14,7 @@
 #include "ipl.h"
 
 const uint PIN_LED = 25;                // Status LED
-const uint PIN_DATA_BASE = 6;           // Base pin used for output, 4 consecutive pins are used 
+const uint PIN_DI = 6;                  // Data output
 const uint PIN_CS = 4;                 // U10 chip select
 const uint PIN_CLK = 5;                // EXI bus clock line
 
@@ -35,15 +35,8 @@ void main()
     // Prioritize DMA engine as it does the most work
     bus_ctrl_hw->priority = BUSCTRL_BUS_PRIORITY_DMA_W_BITS | BUSCTRL_BUS_PRIORITY_DMA_R_BITS;
 
-    gpio_set_slew_rate(PIN_DATA_BASE, GPIO_SLEW_RATE_FAST);
-    gpio_set_slew_rate(PIN_DATA_BASE + 1, GPIO_SLEW_RATE_FAST);
-    gpio_set_slew_rate(PIN_DATA_BASE + 2, GPIO_SLEW_RATE_FAST);
-    gpio_set_slew_rate(PIN_DATA_BASE + 3, GPIO_SLEW_RATE_FAST);
-
-    gpio_set_drive_strength(PIN_DATA_BASE, GPIO_DRIVE_STRENGTH_4MA);
-    gpio_set_drive_strength(PIN_DATA_BASE + 1, GPIO_DRIVE_STRENGTH_4MA);
-    gpio_set_drive_strength(PIN_DATA_BASE + 2, GPIO_DRIVE_STRENGTH_4MA);
-    gpio_set_drive_strength(PIN_DATA_BASE + 3, GPIO_DRIVE_STRENGTH_4MA);
+    gpio_set_slew_rate(PIN_DI, GPIO_SLEW_RATE_FAST);
+    gpio_set_drive_strength(PIN_DI, GPIO_DRIVE_STRENGTH_8MA);
 
     PIO pio = pio0;
 
@@ -57,7 +50,7 @@ void main()
     uint transfer_start_sm = pio_claim_unused_sm(pio, true);
     uint transfer_start_offset = pio_add_program(pio, &on_transfer_program);
 
-    on_transfer_program_init(pio, transfer_start_sm, transfer_start_offset, PIN_CLK, PIN_CS, PIN_DATA_BASE);
+    on_transfer_program_init(pio, transfer_start_sm, transfer_start_offset, PIN_CLK, PIN_CS, PIN_DI);
 
     pio_sm_put(pio, transfer_start_sm, (uint32_t) 224); // CS pulses
     pio_sm_exec(pio, transfer_start_sm, pio_encode_pull(true, true));
@@ -74,7 +67,7 @@ void main()
     uint clocked_output_sm = pio_claim_unused_sm(pio, true);
     uint clocked_output_offset = pio_add_program(pio, &clocked_output_program);
 
-    clocked_output_program_init(pio, clocked_output_sm, clocked_output_offset, PIN_DATA_BASE, PIN_CLK, PIN_CS);
+    clocked_output_program_init(pio, clocked_output_sm, clocked_output_offset, PIN_DI, PIN_CLK, PIN_CS);
 
     pio_sm_put(pio, clocked_output_sm, 8191); // 8192 bits, 1024 bytes, minus 1 because counting starts from 0 
     pio_sm_exec(pio, clocked_output_sm, pio_encode_pull(true, true));

--- a/src/picoboot.pio
+++ b/src/picoboot.pio
@@ -34,6 +34,9 @@ wait_bit:
     mov x, y                    ; Copy y value to x, it represents number of bits in the transfer
     set pindirs 0b10001         ; Set data line as output
 
+    out pins, 1                 ; Output single IPL bit
+    jmp x-- on_rising_edge      ; Decrement x
+
 on_rising_edge:
     wait 0 gpio CLK_PIN         ; Sample until rising edge on CLK line
     wait 1 gpio CLK_PIN

--- a/src/picoboot.pio
+++ b/src/picoboot.pio
@@ -32,14 +32,14 @@ wait_bit:
     wait 1 gpio CLK_PIN
     jmp x-- wait_bit            ; Skip past address bytes
     mov x, y                    ; Copy y value to x, it represents number of bits in the transfer
-    set pindirs 0b11111         ; Set data line as output
+    set pindirs 0b10001         ; Set data line as output
 
 on_rising_edge:
     wait 0 gpio CLK_PIN         ; Sample until rising edge on CLK line
     wait 1 gpio CLK_PIN
 
 write_bit:
-    out pins, 4                 ; Output single IPL bit over 4 GPIOs (=4 bits of our payload)
+    out pins, 1                 ; Output single IPL bit
     jmp x-- on_rising_edge      ; Jump back to next clock pulse wait routine if there is more data to inject
 
     jmp !osre start             ; If there is more data in OSR, go back to start routine and wait for another transfer
@@ -99,7 +99,7 @@ disable_chip:
 
         pio_sm_set_consecutive_pindirs(pio, sm, cs_pin, 2, false); // Set CS and CLK as inputs
 
-        pio_sm_set_consecutive_pindirs(pio, sm, data_pin, 4, false);
+        pio_sm_set_consecutive_pindirs(pio, sm, data_pin, 1, false);
         pio_sm_set_consecutive_pindirs(pio, sm, (data_pin + 4), 1, true); // Debug pin used as output
 
         // Shift to right, autopull with threshold 32


### PR DESCRIPTION
Increasing the output drive strength is enough, no need to output to multiple pins at all.
This also fixes the data output timing to match what EXI expects, thus removing the need to shift the entire payload.